### PR TITLE
Add failing test with zero-length fraction

### DIFF
--- a/test/point-at-test.ts
+++ b/test/point-at-test.ts
@@ -423,3 +423,11 @@ test("TestingDegenerated quadratic curves, issue 43", function (test) {
 
   test.end();
 });
+test("Testing first point of zero length fraction", function (test) {
+  let properties = new SVGPathProperties(
+    "M 0,0 l 0 0 l 10 10"
+  );
+  test.deepEqual(properties.getPointAtLength(0), { x: 0, y: 0 });
+
+  test.end();
+});


### PR DESCRIPTION
Hallo, thanks for this library!

I'm running into an error and added a minimal test case to reproduce it. Basically, a zero-length fraction like "l 0,0" seems to confuse `.getPointAtLength()`. It's an edge case, but I believe that's a valid path, and for me it happens when some paths are generated dynamically.

I'm guessing this function is involved in this:
https://github.com/rveciana/svg-path-properties/blob/master/src/svg-path-properties.ts#L308-L322
My feeling was that it might be advantageous to loop from the beginning, but I couldn't get it to work, as I haven't fully grokked the rest of the code.

Something like this, maybe? But it breaks everything else, so clearly not. :)
```ts
    let i = 0;
    let rest = fractionLength;
    while (i < this.partial_lengths.length && rest > this.partial_lengths[i]) {
      ++i;
      rest -= this.partial_lengths[i];
    }
    return { fraction: rest, i: i - 1 };
```