### PR TITLE
Allow construction using pre-parsed array

### DIFF
--- a/src/svg-path-properties.ts
+++ b/src/svg-path-properties.ts
@@ -9,8 +9,8 @@ export default class SVGPathProperties implements Properties {
   private partial_lengths: number[] = [];
   private functions: (null | Properties)[] = [];
   private initial_point: null | Point = null;
-  constructor(string: string) {
-    const parsed = parse(string);
+  constructor(source: string | [string, ...Array<number>][]) {
+    const parsed = Array.isArray(source) ? source : parse(string);
     let cur: PointArray = [0, 0];
     let prev_point: PointArray = [0, 0];
     let curve: Bezier | undefined;


### PR DESCRIPTION
Hi,

Perhaps it would be useful to be able to instantiate the class using a pre-parsed array?

I have a use case where I use svg-path-commander to parse a bunch of paths beforehand, which I then later use with this library. (this implementation of getPointAtLength is _so_ much faster than path-commanders :)

Thanks for the good work!