### PR TITLE
Support short arc notation

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -23,13 +23,27 @@ export default (path: string) => {
   return segments.reduce((segmentsArray: [string, ...Array<number>][], segmentString: string) => {
     let command = segmentString.charAt(0);
     let type: pathOrders = command.toLowerCase() as pathOrders;
-    const args = parseValues(segmentString.substr(1));
+    let args = parseValues(segmentString.substring(1));
 
     // overloaded moveTo
     if (type === "m" && args.length > 2) {
       segmentsArray.push([command, ...args.splice(0, 2)]);
       type = "l";
       command = command === "m" ? "l" : "L";
+    }
+
+    // overloaded arcTo
+    if (type.toLowerCase() === "a" && args.length === 5) {
+      const aArgs = segmentString.substring(1).trim().split(' ');
+      args = [
+        Number(aArgs[0]),
+        Number(aArgs[1]),
+        Number(aArgs[2]),
+        Number(aArgs[3].charAt(0)),
+        Number(aArgs[3].charAt(1)),
+        Number(aArgs[3].substring(2)),
+        Number(aArgs[4]),
+      ];
     }
 
     while (args.length >= 0) {

--- a/test/parse-test.ts
+++ b/test/parse-test.ts
@@ -60,6 +60,10 @@ test("arcTo, quadratic curveTo, smooth curveTo, smooth quadratic curveTo", funct
     ["A", 30, 50, 0, 0, 1, 162.55, 162.45],
   ]);
 
+  test.deepEqual(parse('a30 50 0 01162.55 162.45'), [
+    ['a', 30, 50, 0, 0, 1, 162.55, 162.45],
+  ]);
+
   test.deepEqual(parse("M10 80 Q 95 10 180 80"), [
     ["M", 10, 80],
     ["Q", 95, 10, 180, 80],


### PR DESCRIPTION
Based on the grammar for path data https://www.w3.org/TR/SVG11/paths.html#PathDataBNF an elliptical arc can have short notation: 'a30 50 0 **01162.55** 162.45' where 01162.55: 0 - large-arc-flag, 1 - sweep-flag and 162.55 - x.