### PR TITLE
Feat/expose segment details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 coverage
+.changesets

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 coverage
-.changesets

--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -1,0 +1,399 @@
+{
+  "name": ".opencode",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@opencode-ai/plugin": "1.18.3"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@opencode-ai/plugin": {
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.3.tgz",
+      "integrity": "sha512-hAm/hZkSCsMSNHVy9DKmFtZAve/qYoIWpduNPcvXnnKK7NMlJEOQitA6CQC67Ym5DFKypDW1TC9YO6S1WdGtpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@opencode-ai/sdk": "1.18.3",
+        "effect": "4.0.0-beta.83",
+        "zod": "4.1.8"
+      },
+      "peerDependencies": {
+        "@opentui/core": ">=0.4.3",
+        "@opentui/keymap": ">=0.4.3",
+        "@opentui/solid": ">=0.4.3"
+      },
+      "peerDependenciesMeta": {
+        "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/keymap": {
+          "optional": true
+        },
+        "@opentui/solid": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.3.tgz",
+      "integrity": "sha512-Mevo4e6kQwbvto9E+42KSIVMhp+JBu+SwQhC5AomAvrV6Xkio3U249T+xDILDCXhl5Z/Hi/DlAuVLzpGnuh0gg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/effect": {
+      "version": "4.0.0-beta.83",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.83.tgz",
+      "integrity": "sha512-0wsak8RtgGAr9UWSbVDgJHZcUqMSvicHcvaZv1MbMM7MCGgW4Rn/137J1MHQbwYPcwYGxT/IqehFd+UbYuj78w==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "fast-check": "^4.8.0",
+        "find-my-way-ts": "^0.1.6",
+        "ini": "^7.0.0",
+        "kubernetes-types": "^1.30.0",
+        "msgpackr": "^2.0.1",
+        "multipasta": "^0.2.7",
+        "toml": "^4.1.1",
+        "uuid": "^14.0.0",
+        "yaml": "^2.9.0"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/find-my-way-ts": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
+      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
+      "license": "MIT"
+    },
+    "node_modules/ini": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz",
+      "integrity": "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==",
+      "license": "ISC",
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/kubernetes-types": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
+      "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/msgpackr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.5.tgz",
+      "integrity": "sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.4"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
+      }
+    },
+    "node_modules/multipasta": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.8.tgz",
+      "integrity": "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q==",
+      "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/toml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-4.3.0.tgz",
+      "integrity": "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.2.tgz",
+      "integrity": "sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.8",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -28,6 +28,65 @@ The available methods are:
     const allProperties = properties.getPropertiesAtLength(200);
     const parts = properties.getParts();
 
+### `getTotalLength()`
+
+Returns the total length of the path.
+
+### `getPointAtLength(pos)`
+
+Returns `{ x, y }` — the coordinates at the given distance along the path.
+
+### `getTangentAtLength(pos)`
+
+Returns `{ x, y }` — the normalized tangent vector at the given distance.
+
+### `getPropertiesAtLength(pos)`
+
+Returns `{ x, y, tangentX, tangentY }` — point and tangent combined.
+
+### `getParts()`
+
+Returns an array of segment objects, one per path command (move commands are skipped). Each object has:
+
+| Property | Description |
+|---|---|
+| `start` | `{ x, y }` — start point of the segment |
+| `end` | `{ x, y }` — end point of the segment |
+| `length` | Arc length of the segment |
+| `getPointAtLength(pos)` | Point at local distance within the segment |
+| `getTangentAtLength(pos)` | Tangent at local distance within the segment |
+| `getPropertiesAtLength(pos)` | Point and tangent combined |
+| `details` | Raw segment parameters (see below) |
+
+#### `details` — segment parameters
+
+Each segment's `details` is a tuple in SVG notation with the **uppercase command letter** and all coordinates in **absolute form**:
+
+| Tuple | Segment type |
+|---|---|
+| `['L', x, y]` | Line to |
+| `['H', x]` | Horizontal line to |
+| `['V', y]` | Vertical line to |
+| `['Z']` | Close path |
+| `['C', cp1x, cp1y, cp2x, cp2y, x, y]` | Cubic Bézier |
+| `['Q', cpx, cpy, x, y]` | Quadratic Bézier |
+| `['A', rx, ry, xRotation, largeArcFlag, sweepFlag, x, y]` | Elliptical arc (`largeArcFlag` and `sweepFlag` are `0` or `1`) |
+
+Example — parametric interpolation along a cubic Bézier at evenly-spaced `t` values instead of arc-length:
+
+    import { svgPathProperties } from "svg-path-properties";
+
+    const parts = new svgPathProperties("M0,0 C10,20 30,40 50,0").getParts();
+    for (const part of parts) {
+      if (part.details[0] === 'C') {
+        const [, cp1x, cp1y, cp2x, cp2y, x, y] = part.details;
+        // evaluate cubic Bézier at t=0.5
+        const t = 0.5;
+        const px = Math.pow(1-t,3)*part.start.x + 3*Math.pow(1-t,2)*t*cp1x + 3*(1-t)*t*t*cp2x + t*t*t*x;
+        const py = Math.pow(1-t,3)*part.start.y + 3*Math.pow(1-t,2)*t*cp1y + 3*(1-t)*t*t*cp2y + t*t*t*y;
+      }
+    }
+
 ### Node
 
     const path = require("svg-path-properties");

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "github": {
+      "type": "local",
+      "command": ["npx", "-y", "@modelcontextprotocol/server-github"],
+      "enabled": true,
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "{env:GITHUB_TOKEN}"
+      }
+    }
+  }
+}

--- a/src/arc.ts
+++ b/src/arc.ts
@@ -1,6 +1,6 @@
-import { Properties, Point, PointProperties } from './types.ts'
+import { SegmentProperties, Point, PointProperties, SegmentDetails } from './types.ts'
 
-export class Arc implements Properties {
+export class Arc implements SegmentProperties {
   private x0: number
   private y0: number
   private rx: number
@@ -103,6 +103,19 @@ export class Arc implements Properties {
     const tangent = this.getTangentAtLength(fractionLength)
     const point = this.getPointAtLength(fractionLength)
     return { x: point.x, y: point.y, tangentX: tangent.x, tangentY: tangent.y }
+  }
+
+  public getDetails = (): SegmentDetails => {
+    return [
+      'A',
+      this.rx,
+      this.ry,
+      this.xAxisRotate,
+      this.LargeArcFlag ? 1 : 0,
+      this.SweepFlag ? 1 : 0,
+      this.x1,
+      this.y1
+    ]
   }
 }
 

--- a/src/bezier.ts
+++ b/src/bezier.ts
@@ -1,4 +1,4 @@
-import { Properties, Point } from './types.ts'
+import { SegmentProperties, Point, SegmentDetails } from './types.ts'
 
 import {
   cubicPoint,
@@ -10,12 +10,13 @@ import {
   t2length
 } from './bezier-functions.ts'
 
-export class Bezier implements Properties {
+export class Bezier implements SegmentProperties {
   private a: Point
   private b: Point
   private c: Point
   private d: Point
   private length: number
+  private isCubic: boolean
   private getArcLength: (xs: number[], ys: number[], t: number) => number
   private getPoint: (xs: number[], ys: number[], t: number) => Point
   private getDerivative: (xs: number[], ys: number[], t: number) => Point
@@ -35,11 +36,13 @@ export class Bezier implements Properties {
     this.c = { x: cx, y: cy }
 
     if (dx !== undefined && dy !== undefined) {
+      this.isCubic = true
       this.getArcLength = getCubicArcLength
       this.getPoint = cubicPoint
       this.getDerivative = cubicDerivative
       this.d = { x: dx, y: dy }
     } else {
+      this.isCubic = false
       this.getArcLength = getQuadraticArcLength
       this.getPoint = quadraticPoint
       this.getDerivative = quadraticDerivative
@@ -98,5 +101,12 @@ export class Bezier implements Properties {
 
   public getD = () => {
     return this.d
+  }
+
+  public getDetails = (): SegmentDetails => {
+    if (this.isCubic) {
+      return ['C', this.b.x, this.b.y, this.c.x, this.c.y, this.d.x, this.d.y]
+    }
+    return ['Q', this.b.x, this.b.y, this.c.x, this.c.y]
   }
 }

--- a/src/linear.ts
+++ b/src/linear.ts
@@ -1,16 +1,20 @@
-import { Properties, Point, PointProperties } from './types.ts'
+import { SegmentProperties, Point, PointProperties, SegmentDetails } from './types.ts'
 
-export class LinearPosition implements Properties {
+export type LinearCommand = 'L' | 'H' | 'V' | 'Z'
+
+export class LinearPosition implements SegmentProperties {
   private x0: number
   private x1: number
   private y0: number
   private y1: number
+  private command: LinearCommand
 
-  constructor (x0: number, x1: number, y0: number, y1: number) {
+  constructor (x0: number, x1: number, y0: number, y1: number, command: LinearCommand = 'L') {
     this.x0 = x0
     this.x1 = x1
     this.y0 = y0
     this.y1 = y1
+    this.command = command
   }
 
   public getTotalLength = () => {
@@ -40,5 +44,14 @@ export class LinearPosition implements Properties {
     const point = this.getPointAtLength(pos)
     const tangent = this.getTangentAtLength(pos)
     return { x: point.x, y: point.y, tangentX: tangent.x, tangentY: tangent.y }
+  }
+
+  public getDetails = (): SegmentDetails => {
+    switch (this.command) {
+      case 'H': return ['H', this.x1]
+      case 'V': return ['V', this.y1]
+      case 'Z': return ['Z']
+      default: return ['L', this.x1, this.y1]
+    }
   }
 }

--- a/src/svg-path-properties.ts
+++ b/src/svg-path-properties.ts
@@ -1,6 +1,6 @@
 /* eslint-disable security/detect-object-injection */
 import parse from './parse.ts'
-import { PointArray, Properties, PartProperties, Point } from './types.ts'
+import { PointArray, Properties, SegmentProperties, PartProperties, Point } from './types.ts'
 import { LinearPosition } from './linear.ts'
 import { Arc } from './arc.ts'
 import { Bezier } from './bezier.ts'
@@ -8,7 +8,7 @@ import { Bezier } from './bezier.ts'
 export default class SVGPathProperties implements Properties {
   private length: number = 0
   private partial_lengths: number[] = []
-  private functions: (null | Properties)[] = []
+  private functions: (null | SegmentProperties)[] = []
   private initial_point: null | Point = null
   constructor (source: string | [string, ...Array<number>][]) {
     const parsed = Array.isArray(source) ? source : parse(source)
@@ -32,34 +32,34 @@ export default class SVGPathProperties implements Properties {
         // lineTo
       } else if (parsed[i][0] === 'L') {
         this.length += Math.hypot(cur[0] - parsed[i][1], cur[1] - parsed[i][2])
-        this.functions.push(new LinearPosition(cur[0], parsed[i][1], cur[1], parsed[i][2]))
+        this.functions.push(new LinearPosition(cur[0], parsed[i][1], cur[1], parsed[i][2], 'L'))
         cur = [parsed[i][1], parsed[i][2]]
       } else if (parsed[i][0] === 'l') {
         this.length += Math.hypot(parsed[i][1], parsed[i][2])
         this.functions.push(
-          new LinearPosition(cur[0], parsed[i][1] + cur[0], cur[1], parsed[i][2] + cur[1])
+          new LinearPosition(cur[0], parsed[i][1] + cur[0], cur[1], parsed[i][2] + cur[1], 'L')
         )
         cur = [parsed[i][1] + cur[0], parsed[i][2] + cur[1]]
       } else if (parsed[i][0] === 'H') {
         this.length += Math.abs(cur[0] - parsed[i][1])
-        this.functions.push(new LinearPosition(cur[0], parsed[i][1], cur[1], cur[1]))
+        this.functions.push(new LinearPosition(cur[0], parsed[i][1], cur[1], cur[1], 'H'))
         cur[0] = parsed[i][1]
       } else if (parsed[i][0] === 'h') {
         this.length += Math.abs(parsed[i][1])
-        this.functions.push(new LinearPosition(cur[0], cur[0] + parsed[i][1], cur[1], cur[1]))
+        this.functions.push(new LinearPosition(cur[0], cur[0] + parsed[i][1], cur[1], cur[1], 'H'))
         cur[0] = parsed[i][1] + cur[0]
       } else if (parsed[i][0] === 'V') {
         this.length += Math.abs(cur[1] - parsed[i][1])
-        this.functions.push(new LinearPosition(cur[0], cur[0], cur[1], parsed[i][1]))
+        this.functions.push(new LinearPosition(cur[0], cur[0], cur[1], parsed[i][1], 'V'))
         cur[1] = parsed[i][1]
       } else if (parsed[i][0] === 'v') {
         this.length += Math.abs(parsed[i][1])
-        this.functions.push(new LinearPosition(cur[0], cur[0], cur[1], cur[1] + parsed[i][1]))
+        this.functions.push(new LinearPosition(cur[0], cur[0], cur[1], cur[1] + parsed[i][1], 'V'))
         cur[1] = parsed[i][1] + cur[1]
         // Close path
       } else if (parsed[i][0] === 'z' || parsed[i][0] === 'Z') {
         this.length += Math.hypot(ringStart[0] - cur[0], ringStart[1] - cur[1])
-        this.functions.push(new LinearPosition(cur[0], ringStart[0], cur[1], ringStart[1]))
+        this.functions.push(new LinearPosition(cur[0], ringStart[0], cur[1], ringStart[1], 'Z'))
         cur = [ringStart[0], ringStart[1]]
         // Cubic Bezier curves
       } else if (parsed[i][0] === 'C') {
@@ -167,7 +167,8 @@ export default class SVGPathProperties implements Properties {
             parsed[i][1],
             parsed[i][3],
             parsed[i][2],
-            parsed[i][4]
+            parsed[i][4],
+            'L'
           )
           this.length += linearCurve.getTotalLength()
           this.functions.push(linearCurve)
@@ -207,7 +208,8 @@ export default class SVGPathProperties implements Properties {
             cur[0] + parsed[i][1],
             cur[0] + parsed[i][3],
             cur[1] + parsed[i][2],
-            cur[1] + parsed[i][4]
+            cur[1] + parsed[i][4],
+            'L'
           )
           this.length += linearCurve.getTotalLength()
           this.functions.push(linearCurve)
@@ -230,7 +232,7 @@ export default class SVGPathProperties implements Properties {
           this.functions.push(curve)
           this.length += curve.getTotalLength()
         } else {
-          const linearCurve = new LinearPosition(cur[0], parsed[i][1], cur[1], parsed[i][2])
+          const linearCurve = new LinearPosition(cur[0], parsed[i][1], cur[1], parsed[i][2], 'L')
           this.functions.push(linearCurve)
           this.length += linearCurve.getTotalLength()
         }
@@ -256,7 +258,8 @@ export default class SVGPathProperties implements Properties {
             cur[0],
             cur[0] + parsed[i][1],
             cur[1],
-            cur[1] + parsed[i][2]
+            cur[1] + parsed[i][2],
+            'L'
           )
           this.length += linearCurve.getTotalLength()
           this.functions.push(linearCurve)
@@ -364,7 +367,7 @@ export default class SVGPathProperties implements Properties {
     const parts: PartProperties[] = []
     for (let i = 0; i < this.functions.length; i++) {
       if (this.functions[i] !== null) {
-        this.functions[i] = this.functions[i] as Properties
+        this.functions[i] = this.functions[i] as SegmentProperties
         const properties: PartProperties = {
           start: this.functions[i]!.getPointAtLength(0),
           end: this.functions[i]!.getPointAtLength(
@@ -373,7 +376,8 @@ export default class SVGPathProperties implements Properties {
           length: this.partial_lengths[i] - this.partial_lengths[i - 1],
           getPointAtLength: this.functions[i]!.getPointAtLength,
           getTangentAtLength: this.functions[i]!.getTangentAtLength,
-          getPropertiesAtLength: this.functions[i]!.getPropertiesAtLength
+          getPropertiesAtLength: this.functions[i]!.getPropertiesAtLength,
+          details: this.functions[i]!.getDetails()
         }
         parts.push(properties)
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,19 @@ export interface Properties {
 }
 
 /**
+ * Extended interface implemented by individual segment classes.
+ * Adds getDetails() on top of the base Properties methods.
+ */
+export interface SegmentProperties extends Properties {
+  /**
+   * Returns the raw geometric parameters of this segment in SVG notation.
+   * The first element is the uppercase command letter; all coordinates are absolute.
+   * @returns A tuple describing the segment type and its parameters
+   */
+  getDetails(): SegmentDetails
+}
+
+/**
  * Properties for a single part (segment) of an SVG path.
  * Each part represents one continuous path element (line, curve, arc, etc.).
  */
@@ -65,6 +78,12 @@ export interface PartProperties {
    * @returns Combined point and tangent properties at the specified position
    */
   getPropertiesAtLength(pos: number): PointProperties
+
+  /**
+   * The raw geometric parameters of this segment in SVG notation.
+   * The first element is the uppercase command letter; all coordinates are absolute.
+   */
+  details: SegmentDetails
 }
 
 /**
@@ -115,3 +134,24 @@ export interface PointProperties {
  * - z: close path
  */
 export type pathOrders = 'a' | 'c' | 'h' | 'l' | 'm' | 'q' | 's' | 't' | 'v' | 'z'
+
+/**
+ * The raw geometric parameters of a path segment, using uppercase SVG command
+ * letters with all coordinates in absolute form.
+ *
+ * - ['L', x, y]                                — line to
+ * - ['H', x]                                   — horizontal line to
+ * - ['V', y]                                   — vertical line to
+ * - ['Z']                                      — close path
+ * - ['C', cp1x, cp1y, cp2x, cp2y, x, y]       — cubic bézier
+ * - ['Q', cpx, cpy, x, y]                      — quadratic bézier
+ * - ['A', rx, ry, xRot, largeArc, sweep, x, y] — elliptical arc (largeArc and sweep as 0 or 1)
+ */
+export type SegmentDetails =
+  | ['L', number, number]
+  | ['H', number]
+  | ['V', number]
+  | ['Z']
+  | ['C', number, number, number, number, number, number]
+  | ['Q', number, number, number, number]
+  | ['A', number, number, number, number, number, number, number]

--- a/test/get-details.test.ts
+++ b/test/get-details.test.ts
@@ -1,0 +1,177 @@
+import SVGPathProperties from '../src/svg-path-properties'
+import assert from 'node:assert'
+import { describe, test } from 'node:test'
+
+// Helper: get details of all parts from a path string
+const details = (path: string) =>
+  new SVGPathProperties(path).getParts().map((p) => p.details)
+
+describe('getDetails', () => {
+  // ─── Linear: L ────────────────────────────────────────────────────────────
+
+  test('L absolute — returns absolute coords', () => {
+    const [d] = details('M10,20 L30,40')
+    assert.deepEqual(d, ['L', 30, 40])
+  })
+
+  test('l relative — converted to absolute coords', () => {
+    const [d] = details('M10,20 l20,20')
+    assert.deepEqual(d, ['L', 30, 40])
+  })
+
+  test('multiple L segments — each has own details', () => {
+    const [d0, d1] = details('M0,0 L10,0 L10,10')
+    assert.deepEqual(d0, ['L', 10, 0])
+    assert.deepEqual(d1, ['L', 10, 10])
+  })
+
+  // ─── Linear: H ────────────────────────────────────────────────────────────
+
+  test('H absolute — returns absolute x', () => {
+    const [d] = details('M10,20 H50')
+    assert.deepEqual(d, ['H', 50])
+  })
+
+  test('h relative — converted to absolute x', () => {
+    const [d] = details('M10,20 h40')
+    assert.deepEqual(d, ['H', 50])
+  })
+
+  // ─── Linear: V ────────────────────────────────────────────────────────────
+
+  test('V absolute — returns absolute y', () => {
+    const [d] = details('M10,20 V80')
+    assert.deepEqual(d, ['V', 80])
+  })
+
+  test('v relative — converted to absolute y', () => {
+    const [d] = details('M10,20 v60')
+    assert.deepEqual(d, ['V', 80])
+  })
+
+  // ─── Linear: Z ────────────────────────────────────────────────────────────
+
+  test('Z close path — returns Z tuple', () => {
+    const [, d] = details('M0,0 L10,0 Z')
+    assert.deepEqual(d, ['Z'])
+  })
+
+  test('z lowercase close path — returns Z tuple', () => {
+    const [, d] = details('M0,0 L10,0 z')
+    assert.deepEqual(d, ['Z'])
+  })
+
+  // ─── Cubic Bézier: C ──────────────────────────────────────────────────────
+
+  test('C absolute cubic — returns all 6 coords', () => {
+    const [d] = details('M0,0 C10,20 30,40 50,0')
+    assert.deepEqual(d, ['C', 10, 20, 30, 40, 50, 0])
+  })
+
+  test('c relative cubic — converted to absolute coords', () => {
+    // Start at (100,200), offsets: cp1(0,-100) cp2(150,-100) end(150,0)
+    const [d] = details('M100,200 c0,-100 150,-100 150,0')
+    assert.deepEqual(d, ['C', 100, 100, 250, 100, 250, 200])
+  })
+
+  // ─── Cubic Bézier: S ──────────────────────────────────────────────────────
+
+  test('S smooth cubic after C — cp1 is reflection of previous cp2', () => {
+    // M100,200 C100,100 250,100 250,200 → cp2=(250,100), end=(250,200)
+    // S: reflected cp1 = 2*250-250=250, 2*200-100=300
+    const [, d] = details('M100,200 C100,100 250,100 250,200 S400,300 400,200')
+    assert.deepEqual(d, ['C', 250, 300, 400, 300, 400, 200])
+  })
+
+  test('S smooth cubic without prior C — cp1 equals start point', () => {
+    const [d] = details('M100,200 S400,300 400,200')
+    assert.deepEqual(d, ['C', 100, 200, 400, 300, 400, 200])
+  })
+
+  test('s relative smooth cubic after C — all coords absolute', () => {
+    const [, d] = details('M100,200 C100,100 250,100 250,200 s150,100 150,0')
+    assert.deepEqual(d, ['C', 250, 300, 400, 300, 400, 200])
+  })
+
+  // ─── Quadratic Bézier: Q ──────────────────────────────────────────────────
+
+  test('Q absolute quadratic — returns cp and end', () => {
+    const [d] = details('M0,0 Q50,100 100,0')
+    assert.deepEqual(d, ['Q', 50, 100, 100, 0])
+  })
+
+  test('q relative quadratic — converted to absolute coords', () => {
+    const [d] = details('M0,0 q50,100 100,0')
+    assert.deepEqual(d, ['Q', 50, 100, 100, 0])
+  })
+
+  test('Q degenerate (cp == start) — falls back to L', () => {
+    // When the control point equals the start, a LinearPosition is used
+    const [d] = details('M10,20 Q10,20 50,60')
+    assert.deepEqual(d, ['L', 50, 60])
+  })
+
+  test('q degenerate (zero offsets) — falls back to L', () => {
+    const [d] = details('M10,20 q0,0 40,40')
+    assert.deepEqual(d, ['L', 50, 60])
+  })
+
+  // ─── Quadratic Bézier: T ──────────────────────────────────────────────────
+
+  test('T smooth quadratic after Q — cp is reflection of previous cp', () => {
+    // Q cp=(50,100), end=(100,0); reflected cp = 2*100-50=150, 2*0-100=-100
+    const [, d] = details('M0,0 Q50,100 100,0 T200,0')
+    assert.deepEqual(d, ['Q', 150, -100, 200, 0])
+  })
+
+  test('T smooth quadratic without prior Q — falls back to L', () => {
+    const [d] = details('M0,0 T100,0')
+    assert.deepEqual(d, ['L', 100, 0])
+  })
+
+  test('t relative smooth quadratic after Q — all coords absolute', () => {
+    const [, d] = details('M0,0 Q50,100 100,0 t100,0')
+    assert.deepEqual(d, ['Q', 150, -100, 200, 0])
+  })
+
+  test('t relative smooth quadratic without prior Q — falls back to L', () => {
+    const [d] = details('M0,0 t100,0')
+    assert.deepEqual(d, ['L', 100, 0])
+  })
+
+  // ─── Arc: A ───────────────────────────────────────────────────────────────
+
+  test('A absolute arc — returns all 7 values with flags as 0/1', () => {
+    const [d] = details('M0,0 A25,26,0,0,1,50,0')
+    assert.deepEqual(d, ['A', 25, 26, 0, 0, 1, 50, 0])
+  })
+
+  test('A arc with largeArcFlag=1 — flag preserved as 1', () => {
+    const [d] = details('M0,0 A25,26,0,1,0,50,0')
+    assert.deepEqual(d, ['A', 25, 26, 0, 1, 0, 50, 0])
+  })
+
+  test('A arc with xAxisRotation — rotation preserved', () => {
+    const [d] = details('M0,0 A25,26,45,0,1,50,0')
+    assert.deepEqual(d, ['A', 25, 26, 45, 0, 1, 50, 0])
+  })
+
+  test('a relative arc — end coords converted to absolute', () => {
+    const [d] = details('M10,20 a25,26,0,0,1,50,0')
+    assert.deepEqual(d, ['A', 25, 26, 0, 0, 1, 60, 20])
+  })
+
+  // ─── Mixed path ───────────────────────────────────────────────────────────
+
+  test('mixed path — each part has correct details in order', () => {
+    const parts = new SVGPathProperties('M0,0 L10,0 H20 V10 C10,5 15,5 20,0 Q5,10 10,0 A5,5,0,0,1,20,0 Z').getParts()
+
+    assert.deepEqual(parts[0].details, ['L', 10, 0], 'L segment')
+    assert.deepEqual(parts[1].details, ['H', 20], 'H segment')
+    assert.deepEqual(parts[2].details, ['V', 10], 'V segment')
+    assert.deepEqual(parts[3].details, ['C', 10, 5, 15, 5, 20, 0], 'C segment')
+    assert.deepEqual(parts[4].details, ['Q', 5, 10, 10, 0], 'Q segment')
+    assert.deepEqual(parts[5].details, ['A', 5, 5, 0, 0, 1, 20, 0], 'A segment')
+    assert.deepEqual(parts[6].details, ['Z'], 'Z segment')
+  })
+})


### PR DESCRIPTION
Closes #129

## Summary

Adds the ability to retrieve the raw geometric parameters of each path segment, so callers can do parametric interpolation (e.g. evaluating a cubic Bézier at evenly-spaced `t` values) without needing a second library.

## Changes

### New type: `SegmentDetails`

A discriminated tuple union in SVG notation with uppercase command letters and absolute coordinates:

| Tuple | Segment |
|---|---|
| `['L', x, y]` | Line to |
| `['H', x]` | Horizontal line to |
| `['V', y]` | Vertical line to |
| `['Z']` | Close path |
| `['C', cp1x, cp1y, cp2x, cp2y, x, y]` | Cubic Bézier |
| `['Q', cpx, cpy, x, y]` | Quadratic Bézier |
| `['A', rx, ry, xRot, largeArc, sweep, x, y]` | Elliptical arc |

### New method: `getDetails()` on all segment classes

`LinearPosition`, `Bezier`, and `Arc` all implement `getDetails(): SegmentDetails`. Added to the `Properties` interface.

### New field: `details` on `PartProperties`

`getParts()` now includes a `details` field on every returned segment object.

### Notes

- `H` and `V` preserve their original command type (not collapsed to `L`)
- All coordinates are absolute regardless of whether the original command was relative
- Degenerate `Q`/`q` and `T`/`t` fallbacks that produce a `LinearPosition` return `['L', x, y]`
- `largeArcFlag` and `sweepFlag` are exposed as `0` or `1`

## Tests

27 new tests in `test/get-details.test.ts` covering all segment types, relative-to-absolute conversion, smooth curve reflection, degenerate fallbacks, and a mixed-path end-to-end check.]