### PR TITLE
Give a tangent where a control point sits on its anchor

### DIFF
--- a/src/bezier.ts
+++ b/src/bezier.ts
@@ -10,6 +10,10 @@ import {
   t2length
 } from './bezier-functions.ts'
 
+// How far along the curve to look when the derivative vanishes at t. Small
+// enough that the direction is the limit, large enough to survive rounding.
+const TANGENT_EPSILON = 1e-8
+
 export class Bezier implements SegmentProperties {
   private a: Point
   private b: Point
@@ -55,8 +59,23 @@ export class Bezier implements SegmentProperties {
     )
   }
 
-  private normalizeTangent = (derivative: Point): Point => {
-    const mdl = Math.hypot(derivative.x, derivative.y)
+  private normalizeTangent = (
+    xs: number[],
+    ys: number[],
+    t: number
+  ): Point => {
+    let derivative = this.getDerivative(xs, ys, t)
+    let mdl = Math.hypot(derivative.x, derivative.y)
+
+    if (mdl === 0) {
+      // The derivative vanishes where a control point sits on its anchor, but
+      // the curve still has a tangent there. Take the limit from just along
+      // the curve, forwards where there is room and backwards at the end.
+      const nudged = t < 1 ? t + TANGENT_EPSILON : t - TANGENT_EPSILON
+      derivative = this.getDerivative(xs, ys, nudged)
+      mdl = Math.hypot(derivative.x, derivative.y)
+    }
+
     if (mdl > 0) {
       return { x: derivative.x / mdl, y: derivative.y / mdl }
     }
@@ -80,8 +99,7 @@ export class Bezier implements SegmentProperties {
     const xy = [this.a.y, this.b.y, this.c.y, this.d.y]
     const t = t2length(length, this.length, (i) => this.getArcLength(xs, xy, i))
 
-    const derivative = this.getDerivative(xs, xy, t)
-    return this.normalizeTangent(derivative)
+    return this.normalizeTangent(xs, xy, t)
   }
 
   public getPropertiesAtLength = (length: number) => {
@@ -89,8 +107,7 @@ export class Bezier implements SegmentProperties {
     const xy = [this.a.y, this.b.y, this.c.y, this.d.y]
     const t = t2length(length, this.length, (i) => this.getArcLength(xs, xy, i))
 
-    const derivative = this.getDerivative(xs, xy, t)
-    const tangent = this.normalizeTangent(derivative)
+    const tangent = this.normalizeTangent(xs, xy, t)
     const point = this.getPoint(xs, xy, t)
     return { x: point.x, y: point.y, tangentX: tangent.x, tangentY: tangent.y }
   }

--- a/test/tangent.test.ts
+++ b/test/tangent.test.ts
@@ -5,6 +5,29 @@ import assert from 'node:assert'
 import { describe, test } from 'node:test'
 
 describe('Tangent calculations', () => {
+  test('tangent is a unit vector where a control point sits on its anchor', () => {
+    // The first derivative vanishes at such an endpoint, but the curve still
+    // has a tangent there.
+    const cases: [string, 'start' | 'end', [number, number]][] = [
+      // S with no preceding C: the reflected control point is the start point
+      ['M100,200 S400,300 400,200', 'start', [0.9486832980505138, 0.31622776601683794]],
+      // cubic with cp1 on the start point
+      ['M0,0 C0,0 50,100 100,0', 'start', [0.4472135954999579, 0.8944271909999159]],
+      // cubic with cp2 on the end point
+      ['M0,0 C50,100 100,0 100,0', 'end', [0.4472135954999579, -0.8944271909999159]]
+    ]
+
+    for (const [path, where, [wantX, wantY]] of cases) {
+      const properties = new SVGPathProperties(path)
+      const pos = where === 'start' ? 0 : properties.getTotalLength()
+      const tangent = properties.getTangentAtLength(pos)
+
+      assert.strictEqual(inDelta(Math.hypot(tangent.x, tangent.y), 1, 1e-6), true, path)
+      assert.strictEqual(inDelta(tangent.x, wantX, 1e-6), true, path)
+      assert.strictEqual(inDelta(tangent.y, wantY, 1e-6), true, path)
+    }
+  })
+
   test('getTangentAtLength testing', function (test) {
     const paths = [
       {
@@ -121,13 +144,16 @@ describe('Tangent calculations', () => {
       },
       {
         path: 'M100,200 S400,300 400,200',
+        // The S has no preceding C, so its reflected control point is the start
+        // point and the derivative vanishes at t=0. The tangent there is still
+        // (300,100) normalized, the direction of the second control point.
         xValues: [
-          0, 0.9647425496827284, 0.9760648482761272, 0.9886843239589528, 0.9995932816004552,
-          0.953018740113177, 2.2070215559197298e-7
+          0.9486832980505138, 0.9647425496827284, 0.9760648482761272, 0.9886843239589528,
+          0.9995932816004552, 0.953018740113177, 2.2070215559197298e-7
         ],
         yValues: [
-          0, 0.26319538907752243, 0.21747968171693818, 0.15001102478760836, 0.028517913304325987,
-          -0.30291134180332835, -0.9999999999999756
+          0.31622776601683794, 0.26319538907752243, 0.21747968171693818, 0.15001102478760836,
+          0.028517913304325987, -0.30291134180332835, -0.9999999999999756
         ]
       },
       {


### PR DESCRIPTION
## The problem

`getTangentAtLength` returns `{x: 0, y: 0}` at either end of a cubic whose adjacent control point coincides with the anchor:

| path | pos | expected | actual |
|---|---|---|---|
| `M100,200 S400,300 400,200` | 0 | `{x: 0.94868, y: 0.31623}` | `{x: 0, y: 0}` |
| `M0,0 C0,0 50,100 100,0` | 0 | `{x: 0.44721, y: 0.89443}` | `{x: 0, y: 0}` |
| `M0,0 C50,100 100,0 100,0` | totalLength | `{x: 0.44721, y: -0.89443}` | `{x: 0, y: 0}` |
| `M0,0 C0,0 50,100 100,0` | 70 (control) | normalized | `{x: 0.99910, y: 0.04235}` ✓ |

`getPropertiesAtLength(0)` carries it through: `{"x":0,"y":0,"tangentX":0,"tangentY":0}`.

The docs promise otherwise:

> Returns `{ x, y }` — the normalized tangent vector at the given distance.
> — `README.md:41`, repeated at `src/main.ts:71` and `src/types.ts:22`

A zero vector is not normalized, and the curve is not degenerate — it has full arc length and a well-defined tangent at that point. The derivative just vanishes there, since the hodograph evaluates to `3(P1-P0)` at `t=0` and `3(P3-P2)` at `t=1`.

## This is an ordinary path, not a contrived one

An `S`/`s` with no preceding cubic has its reflected control point set to the current point *by definition*, so the first case above is a plain SVG path. The repo's own test suite covers that expansion (`test/get-details.test.ts`, "S smooth cubic without prior C — cp1 equals start point"). Design-tool exports with a zero-length handle on one side of a node produce the same shape.

## The library already handles the quadratic version

`M0,0 Q0,0 100,0` at position 0 returns `{x: 1, y: 0}` — correct — because that case degrades to a `LinearPosition`. Only the cubic path lacked a fallback.

## The change

When the derivative is zero, take the direction from just along the curve instead. The derivative is a polynomial that vanishes only at isolated points, so the limit from inside is the geometric tangent, and reading forwards (backwards at the end, where there is no room ahead) keeps the sign pointing along the path.

I checked the accuracy against the closed form rather than assuming it: with `TANGENT_EPSILON = 1e-8` the direction matches `P2-P1` (and `P2-P1` again at the far end, correctly signed) to within 4e-9, and the error scales linearly with epsilon, as a clean limit should.

## One existing expectation changed

The tangent table asserted the old `{0, 0}` for `M100,200 S400,300 400,200` at position 0. I corrected that single pair and left a comment saying why.

The entry immediately below it in the same table is the argument that this is right: `M100,200 C100,100 250,100 250,200 S400,300 400,200` has a *real* reflected control point and already expects a unit vector at the same position. The other six sample points of the changed path, and every other path in the table, are untouched.

## Tests

Added `tangent is a unit vector where a control point sits on its anchor`, covering the start-side and end-side cases and asserting magnitude 1 as well as direction — the old expectation would have passed a magnitude check by accident, so the test asserts both.

Reverting only `src/bezier.ts` and keeping the tests fails both the new test and the corrected table entry.

Suite: 61 passing before, 62 after.

---

*Disclosure: this patch was prepared with AI assistance. The reproduction, the closed-form accuracy check, the red/green check and the suite runs above were executed against this branch; happy to adjust anything on request.*
